### PR TITLE
Introduced the Slugger Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This documentation is still under construction. However, an example is provided 
 ### Contributors
 * Sam Jarrett (samjarrett@me.com)
 * Denis Chartier (denis.chart+git@gmail.com)
+* Cameron Manderson (cameronmanderson@gmail.com)
 
 Installation
 ------------
@@ -32,6 +33,7 @@ Example Entities
 
 ### Example 1
 In this example, the slug is built based on a single field:
+Note: Make sure you implement the accessor methods getId and getTitle
 
 #### Code
 	<?php
@@ -90,6 +92,7 @@ i.e.: an entity with a title of `Test Post` will have a slug of `test-post`.
 
 ### Example 2
 In this example, the slug is built based on multiple single fields:
+Note: Make sure you implement the accessor methods getId, getTitle and getAuthor
 
 #### Code
 	<?php
@@ -105,7 +108,7 @@ In this example, the slug is built based on multiple single fields:
 	 * @ORM\Entity
 	 * @ORM\Table
 	 */
-	class SingleFieldExample implements SluggableInterface {
+	class MultipleSingleFieldExample implements SluggableInterface {
 		/**
 		 * @ORM\Id
 		 * @ORM\Column(type="integer")
@@ -150,3 +153,7 @@ In this example, the slug is built based on multiple single fields:
 When the entity is persisted, the $slug field will be populated to be a 0-9, a-z only, with spaces converted to hyphens ("-"), based upon the author and title field.
 
 i.e.: an entity with a author of `Sam Jarrett` and a title of `Test Post` will have a slug of `sam-jarrett-test-post`.
+
+#### Further Notes
+This bundle uses a service called the "Slugger". You can implement your own slugger behaviour (such as dealing with specific field ordering etc) by implementing the SluggerInterface->getSlug($fields) method. Configure your service container to specific the class in the parameter "sluggable.slugger.class" in your service.xml.
+

--- a/src/SamJ/DoctrineSluggableBundle/Listener/SluggableListener.php
+++ b/src/SamJ/DoctrineSluggableBundle/Listener/SluggableListener.php
@@ -3,14 +3,26 @@
 namespace SamJ\DoctrineSluggableBundle\Listener;
 
 use SamJ\DoctrineSluggableBundle\SluggableInterface;
+use SamJ\DoctrineSluggableBundle\SluggerInterface;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ *
+ * @TODO: Eliminate dependency on 'getId' from the entity from the interface
+ */
 class SluggableListener 
 {
-	protected static $issuedSlugs = array();
+    protected $slugger;
+
+    /**
+     * @param Slugger $slugger
+     */
+    public function __construct(SluggerInterface $slugger) {
+        $this->slugger = $slugger;
+    }
 
 	public function prePersist(LifecycleEventArgs $ea)
 	{
@@ -28,36 +40,36 @@ class SluggableListener
 		return $em->getRepository(get_class($entity));
 	}
 
+    /**
+     * @param \SamJ\DoctrineSluggableBundle\SluggableInterface $entity
+     * @param \Doctrine\ORM\EntityRepository $repository
+     * @return void
+     *
+     * @TODO: Remove the dependency on the field 'slug' on the entity (not in interface)
+     * @TODO: Discuss whether the slug should auto-update if it is an 'update' (behaviour?)
+     */
 	protected function generateUniqueSlug(SluggableInterface $entity, EntityRepository $repository)
 	{
-		if (!isset(self::$issuedSlugs[get_class($entity)])) self::$issuedSlugs[get_class($entity)] = array();
+		// Find a slug
+        $eliminated = array(); // Our prior eliminated slugs
+        $foundSlug = false;
+		do {
+            // Obtain our slug
+            $slug = $this->slugger->getSlug($entity->getSlugFields(), $eliminated);
 
-		$slug = is_array($entity->getSlugFields()) ? implode('-', $entity->getSlugFields()) : $entity->getSlugFields();
-		// replace non letter or digits by -
-		$slug = preg_replace('~[^\\pL\d]+~u', '-', $slug);
-		// trim
-		$slug = trim($slug, '-');
-		// transliterate
-		if(function_exists('iconv')):
-				$slug = iconv('utf-8', 'us-ascii//TRANSLIT', $slug);
-		endif;
-		// lowercase
-		$slug = strtolower($slug);
-		// remove unwanted characters
-		$slug = preg_replace('~[^-\w]+~', '', $slug);
-		$loops = 0;
-		do
-		{
-			++$loops;
-			$testSlug = $slug;
-			if ($loops > 1) $testSlug .= '-' . $loops;
+            // See if it is in our collection
+            $result = $repository->findOneBy(array('slug' => $slug));
 
-			$result = $repository->findOneBy(array('slug' => $testSlug));
-		} while ((!empty($result) && $result->getId() != $entity->getId()) ||
-		         in_array($testSlug, self::$issuedSlugs[get_class($entity)]));
+            // Check to see if we have found a slug that matches
+            if(!empty($result) && $result->getId() != $entity->getId()) {
+                $eliminated[] = $slug;
+            } else {
+                // We have found a slug for this element
+                $foundSlug = true;
+            }
+		} while ($foundSlug === false);
 
-		$entity->setSlug($testSlug);
-		
-		self::$issuedSlugs[get_class($entity)][] = $testSlug;
+        // Set the slug back to the entity
+		$entity->setSlug($slug);
 	}
 }

--- a/src/SamJ/DoctrineSluggableBundle/Resources/config/services.xml
+++ b/src/SamJ/DoctrineSluggableBundle/Resources/config/services.xml
@@ -4,9 +4,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="sluggable.slugger.class">SamJ\DoctrineSluggableBundle\Slugger</parameter>
+    </parameters>
+
     <services>
         <service id="sluggable.listener" class="SamJ\DoctrineSluggableBundle\Listener\SluggableListener">
             <tag name="doctrine.event_listener" event="prePersist" />
+            <argument type="service" id="sluggable.slugger" />
         </service>
+        <service id="sluggable.slugger" class="%sluggable.slugger.class%"/>
     </services>
 </container>

--- a/src/SamJ/DoctrineSluggableBundle/SluggableInterface.php
+++ b/src/SamJ/DoctrineSluggableBundle/SluggableInterface.php
@@ -4,6 +4,7 @@ namespace SamJ\DoctrineSluggableBundle;
 
 interface SluggableInterface
 {
+    public function getId();
 	public function setSlug($slug);
 	public function getSlugFields();
 }

--- a/src/SamJ/DoctrineSluggableBundle/Slugger.php
+++ b/src/SamJ/DoctrineSluggableBundle/Slugger.php
@@ -1,0 +1,59 @@
+<?php
+namespace SamJ\DoctrineSluggableBundle;
+
+use SamJ\DoctrineSluggableBundle\SluggerInterface;
+
+/**
+ * Object Service that generates a slug based on incoming fields
+ * e.g. "My Test" will return "my-test" ("my-test-1" on duplicate)
+ *
+ * @author camm (cameronmanderson@gmail.com)
+ */
+class Slugger implements SluggerInterface {
+
+    /**
+     * Return a slug, ensuring it does not appear in exclude (prior collisions)
+     * @param $fields
+     * @param array $exclude list of slugs to exclude
+     * @return void
+     * Reference: Doctrine 1_4 slugify
+     */
+    public function getSlug($fields, $exclude = array())
+    {
+        // Determine if we are dealing with single-field or multiple-field slugs
+        if(is_array($fields)) {
+            $value = implode('-', $fields);
+        } else {
+            $value = $fields;
+        }
+
+        // Treat the data (eliminate non-letter or digits by '-'
+        $slug = preg_replace('~[^\\pL\d]+~u', '-', $value);
+
+        // Clean up the slug
+		$slug = trim($slug, '-');
+
+		// Translate
+		if(function_exists('iconv')) {
+            $slug = iconv('utf-8', 'us-ascii//TRANSLIT', $slug);
+        }
+
+		// Lowercase
+		$slug = strtolower($slug);
+
+		// Remove unwanted characters
+		$slug = preg_replace('~[^-\w]+~', '', $slug);
+
+        // Fall-back to produce something
+        if(!trim($slug)) $slug = 'n-a';
+
+        // Append an index to the slug and see if we can generate a unique value
+        $loop = 0;
+        do $test = $slug . ('-' . ++$loop);
+        while(in_array($test, $exclude));
+        $slug = $test;
+
+        // We have our unique slug suggestion
+        return $slug;
+    }
+}

--- a/src/SamJ/DoctrineSluggableBundle/SluggerInterface.php
+++ b/src/SamJ/DoctrineSluggableBundle/SluggerInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace SamJ\DoctrineSluggableBundle;
+
+/**
+ * An interface for creating services that can generate a slug for a doctrine entity
+ * @author camm (cameronmanderson@gmail.com)
+ */
+interface SluggerInterface {
+    /**
+     * Return a slug, ensuring it does not appear in exclude (prior collisions)
+     * @abstract
+     * @param $fields
+     * @param array $exclude list of slugs to exclude
+     * @return void
+     */
+    public function getSlug($fields, $exclude = array());
+}


### PR DESCRIPTION
Refactored the object graph to split logic that generates the slug from the Listener into an object service named the Slugger. This allows other developers to implement their own slug generation and specify using the Service XML (DI). 

This allows authors the flexibility to create slugs based on the known fields (e.g. in example; "example-document-by-cam") or handle collisions differently (e.g. in example; "example-document-2-by-cam"). 

This also allows for better independent testing of the logic around generating of slugs, as you can simply create the service, punch in test data (e.g. bad characters etc) and test the result without dependencies.

Updated the documentation, introduced a SluggerInterface and implementation of Slugger (based on the slugify doctrine method). Removed the static implementation of the collection of collisions and passed through to the slugger.
